### PR TITLE
Update crc-utils to use the built in 4GB part normalization

### DIFF
--- a/lib.coffee
+++ b/lib.coffee
@@ -51,20 +51,7 @@ exports.createGzipFromParts = (parts) ->
 	# write ending DEFLATE part
 	out.append(DEFLATE_END)
 	# write CRC
-	# 🤖-explanation: The CRC32 shift matrix M has period T = 2^32-1 (primitive polynomial),
-	# so M^n = M^(n mod T). Reduce each part's len mod T before passing to
-	# crc32_combine_multi, which accepts len as a 32-bit integer.
-	# Special case: if n mod T = 0 (and n > 0), use T instead of 0 to avoid
-	# the len=0 early-return in crc32_combine that would ignore crc2.
-	CRC32_PERIOD_NUMBER = 0xffffffff; # T = 2^32-1
-	normalizedParts = parts.map (p) ->
-		if p.len <= CRC32_PERIOD_NUMBER
-			return p
-		len = p.len % CRC32_PERIOD_NUMBER
-		if len == 0
-			len = CRC32_PERIOD_NUMBER
-		return { crc: p.crc, len: len }
-	out.append(crcUtils.crc32_combine_multi(normalizedParts).combinedCrc32)
+	out.append(crcUtils.crc32_combine_multi(parts).combinedCrc32)
 	# write the ISIZE length, modulo 2^32 per RFC 1952 section 2.3.1
 	# https://www.rfc-editor.org/info/rfc1952/#page-8:~:text=original%20(uncompressed)%20input-,data%20modulo%202%5E32
 	len = Buffer.alloc(4)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@balena/node-crc-utils": "^3.0.0",
+        "@balena/node-crc-utils": "^3.1.0",
         "combined-stream": "^1.0.8",
         "crc32-stream": "^4.0.0"
       },
@@ -21,9 +21,9 @@
       }
     },
     "node_modules/@balena/node-crc-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@balena/node-crc-utils/-/node-crc-utils-3.0.0.tgz",
-      "integrity": "sha512-Gczabj4pMZ/ZstbgmdP8FcUoIYD3K/59TlTOPF3O2gfFyruRLR55620ESpJiF4Et93PeXy4yoJNFh7c35Y8xig==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@balena/node-crc-utils/-/node-crc-utils-3.1.0.tgz",
+      "integrity": "sha512-JgjpHANlOcafomOW6Vw7oHQlNR4Vc1GinLDfbzQiEr9CJTohwA+7uO/rsRz08lyRtWu1fIAXOjvK9dZ6GyKsTA==",
       "engines": {
         "node": ">=16"
       }
@@ -136,9 +136,9 @@
   },
   "dependencies": {
     "@balena/node-crc-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@balena/node-crc-utils/-/node-crc-utils-3.0.0.tgz",
-      "integrity": "sha512-Gczabj4pMZ/ZstbgmdP8FcUoIYD3K/59TlTOPF3O2gfFyruRLR55620ESpJiF4Et93PeXy4yoJNFh7c35Y8xig=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@balena/node-crc-utils/-/node-crc-utils-3.1.0.tgz",
+      "integrity": "sha512-JgjpHANlOcafomOW6Vw7oHQlNR4Vc1GinLDfbzQiEr9CJTohwA+7uO/rsRz08lyRtWu1fIAXOjvK9dZ6GyKsTA=="
     },
     "coffeescript": {
       "version": "2.7.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "Balena Ltd. <hello@balena.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@balena/node-crc-utils": "^3.0.0",
+    "@balena/node-crc-utils": "^3.1.0",
     "combined-stream": "^1.0.8",
     "crc32-stream": "^4.0.0"
   },


### PR DESCRIPTION
Change-type: patch
See: https://github.com/balena-io-modules/node-crc-utils/pull/8